### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ envconfig
 .. image:: https://coveralls.io/repos/dbader/envconfig/badge.png
         :target: https://coveralls.io/r/dbader/envconfig
 
-.. image:: https://pypip.in/v/envconfig/badge.png
+.. image:: https://img.shields.io/pypi/v/envconfig.svg
         :target: https://pypi.python.org/pypi/envconfig
 
 A module for reading configuration values from the OS environment variables.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20envconfig))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `envconfig`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.